### PR TITLE
get rid of xalan dependency; simplify dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.18.1</version>
+			<version>3.26.3</version>
 			<scope>test</scope>
 		</dependency>
 		
@@ -65,17 +65,7 @@
 		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
-			<version>3.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>xalan</groupId>
-			<artifactId>xalan</artifactId>
-			<version>2.7.3</version>
-		</dependency>
-		<dependency>
-			<groupId>xalan</groupId>
-			<artifactId>serializer</artifactId>
-			<version>2.7.3</version>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -94,13 +84,12 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>com.sun.xml.ws</groupId>
-			<artifactId>jaxws-ri</artifactId>
-			<version>3.0.2</version>
-			<type>pom</type>
+		  <groupId>jakarta.xml.ws</groupId>
+		  <artifactId>jakarta.xml.ws-api</artifactId>
+		  <version>4.0.2</version>
 		</dependency>
 	</dependencies>
-	
+
 	
 	<build>
 		<plugins>

--- a/src/main/java/eu/unicore/samly2/attrprofile/ParsedAttribute.java
+++ b/src/main/java/eu/unicore/samly2/attrprofile/ParsedAttribute.java
@@ -25,6 +25,8 @@ import xmlbeans.org.oasis.saml2.assertion.AttributeType;
  */
 public class ParsedAttribute implements Serializable
 {
+	private static final long serialVersionUID = 1L;
+
 	private String name;
 	private String description;
 	

--- a/src/main/java/eu/unicore/samly2/exceptions/SAMLErrorResponseException.java
+++ b/src/main/java/eu/unicore/samly2/exceptions/SAMLErrorResponseException.java
@@ -15,6 +15,8 @@ import eu.unicore.samly2.SAMLConstants.SubStatus;
 public class SAMLErrorResponseException extends SAMLServerException
 {
 
+	private static final long serialVersionUID = 1L;
+
 	public SAMLErrorResponseException(Status samlErrorId, String message, Throwable cause)
 	{
 		super(samlErrorId, message, cause);

--- a/src/main/java/eu/unicore/samly2/trust/DsigSamlTrustCheckerBase.java
+++ b/src/main/java/eu/unicore/samly2/trust/DsigSamlTrustCheckerBase.java
@@ -109,6 +109,8 @@ public abstract class DsigSamlTrustCheckerBase implements SamlTrustChecker
 	
 	public class SAMLTrustedKeyDiscoveryException extends RuntimeException
 	{
+		private static final long serialVersionUID = 1L;
+
 		public SAMLTrustedKeyDiscoveryException(String message)
 		{
 			super(message);


### PR DESCRIPTION
I noted that samly could use one or two updates, and that some dependencies are not needed, these changes will make life a bit easier downstream.